### PR TITLE
Issue 58/item 50 use packages to organize modules

### DIFF
--- a/chapter_7_collaboration/item_50_use_packages_to_organize_modules.ipynb
+++ b/chapter_7_collaboration/item_50_use_packages_to_organize_modules.ipynb
@@ -1,0 +1,370 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Item 50: Use Packages to Organize Modules and Provide Stable APIs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* As the size of a program's codebase grows, it's natural to reorganize its structure.\n",
+    "* Split larger functions into smaller functions, refactor data structures into helper classes.\n",
+    "    * See `Item 22`: Prefer Helper Classes Over Bookkeeping with Dictionaries and Tuples.\n",
+    "    * Separate functionality into various modules that depend on each other.\n",
+    "* Python provides packages.\n",
+    "    * `Packages` are modules that contain other `modules`.\n",
+    "    * In most cases, packages are defined by putting an empty file named `__init__`.py into a directory.\n",
+    "    * Once `__init__.py` is present, any other Python files in that directory will be available for import using a path relative to the directory."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "main.py\n",
+    "mypackage/__init__.py\n",
+    "mypackage/models.py\n",
+    "mypackage/utils.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* To import the `utils` module, you use the absolute module name that includes the package directory's name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # main.py\n",
+    "# from mypackage import utils"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Note\n",
+    "    * Python 3.4 introduces `namespace` packages, a more flexible way to define packages.\n",
+    "    * `Namespace` packages can be composed of modules from completely separate directories, zip archives, or even remote systems.\n",
+    "    * See `PEP 420` (http://www.python.org/dev/peps/pep-0420/)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* The functionality provided by packages has two primary purposes in Python programs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Namespaces"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* The first use o fpackages is to help divide your modules into separate namespaces.\n",
+    "    * This allows you to have many modules with the same filename but different absolute paths that are unique.\n",
+    "    * e.g.\n",
+    "        * A program that imports attributes from two modules with the same name.\n",
+    "        * Best try to avoid `imported name conflict`!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # main.py\n",
+    "# from analysis.utils import log_base2_bucket\n",
+    "# from frontend.utils import stringify\n",
+    "\n",
+    "# bucket = stringify(log_base2_bucket(33))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Problem 1\n",
+    "\n",
+    "    * This approach breaks down when the functions, classes, or submoules defined in packages have the same names.\n",
+    "    * Importing the attributes directly won't work because the second import statement will overwrite the value of inspect in the current scope."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # main2.py\n",
+    "# from analysis.utils import inspect\n",
+    "# from frontend.util import inspect  # overwrites!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Solution:\n",
+    "\n",
+    "    * Use the `as` clause of the import statement to rename whatever you've imported for the current scope.\n",
+    "    * The `as` clause can be used to rename anything you retrieve with the `import` statement, including entire modules."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # main3.py\n",
+    "# from analysis.utils import inspect as analysis_inspect\n",
+    "# from frontend.utils import inspect as frontend_inspect\n",
+    "\n",
+    "# value = 33\n",
+    "# if analysis_inspect(value) == frontend_inspect(value):\n",
+    "#     print('Inspection equal!')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Note\n",
+    "\n",
+    "    * Another approach for avoiding `imported name conflicts` is to always access names by their highest unique module name.\n",
+    "    * e.g.\n",
+    "        * First import:\n",
+    "            * import analysis.utils\n",
+    "            * import frontend.utils\n",
+    "        * Then, access the inspect functions with the full paths:\n",
+    "            * analysis.utils.inspect\n",
+    "            * frontend.utils.inspect"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Stable APIs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* The second use of packages in Python is to provide strict, stable APIs for external consumers.\n",
+    "* When writing an API for wider consumption, like an open source package, you'll want to provide stable functionality that doesn't change between releases.\n",
+    "    * See `Item 48`: Know Where to Find Community-Built Modules.\n",
+    "* To ensure that happens, it's important to hide your internal code organization from external users.\n",
+    "    * This enables you to refactore and improve your package's internal modules without breaking existing users."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Python can limit the surface area exposed to API consumers by using the `__all__` special attribute of a module or package.\n",
+    "* The value of `__all__` is a list of every name to export from the module as part of its `public API`.\n",
+    "    * When you run `from foo import *`, only the attributes in `foo.__all__` will be imported from foo.\n",
+    "    * If `__all__` isn't present in foo, then only public attributes (those without a leading underscore) are imported.\n",
+    "        * See `Item 27`: Prefer Public Attributes Over Private Ones"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # models.py\n",
+    "# __all__ = ['Projectile']\n",
+    "\n",
+    "# class Projectile(object):\n",
+    "#     def __init__(self, mass, velocity):\n",
+    "#         self.mass = mass\n",
+    "#         self.velocity = velocity\n",
+    "        \n",
+    "# # utils.py\n",
+    "# from . models import Projectile\n",
+    "\n",
+    "# __all__ = ['simulate_collision']\n",
+    "\n",
+    "# def _dot_product(a, b):\n",
+    "#     ...\n",
+    "\n",
+    "# def simulate_collision(a, b):\n",
+    "#     ..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* All of the public parts of this API as a set of attributes that are available on the mypackage module.\n",
+    "* Consumers can always import directly from mypackage instead of importing `from mypackage.models` or `mypackage.utils`.\n",
+    "* This ensures that the API consumer's code will continue to work even if the internal organization of mypackage changes:\n",
+    "    * e.g. models.py is deleted"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* To do this with Python packages, you need to modify the `__init__.py` file in the mypackage directory.\n",
+    "* This file actually becomes the contents of the mypackage module when it's imported.\n",
+    "    * You can specify an explicit API for mypackage by limiting what you import into `__init__.py`.\n",
+    "    * Since all of the internal modules already specify `__all__`, I can expose the public interface of mypackage by simply importing everything from the internal modules and updating `__all__` accordingly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # __init__.py\n",
+    "# __all__ = []\n",
+    "\n",
+    "# from . models import *\n",
+    "# __all__+= models.__all__\n",
+    "\n",
+    "# from . utils import *\n",
+    "# __all__ += utils.__all__"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Consumer of the API that directly imports from mypackage instead of accessing the inner modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # api_consumer.py\n",
+    "# from mypackage import *\n",
+    "\n",
+    "# a = Projectile(1.5, 3)\n",
+    "# b = Projectile(4, 1.7)\n",
+    "# after_a, after_b = simulate_collision(a, b)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Internal-only functions like `mypackage.utils._dot_product` will not be available to the API consumer on mypackage.\n",
+    "    * They weren't present in `__all__`.\n",
+    "    * Being omitted from `__all__` means they weren't imported by the `from mypackage import *` statement.\n",
+    "    * The internal-only names are effectively hidden."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Note:\n",
+    "    \n",
+    "    * This whole approach works great when it's important to provide an explicit, stable API.\n",
+    "    * If you're building an API for use between your own modules, the functionality of `__all__` is probably unnecessaryand should be avoided.\n",
+    "        * The `namespacing` provided by packages is usually enough for a team of programmers to collaborate on large amounts of code.\n",
+    "        * They control while maintaining reasonable interface boundaries."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Beware of import `*`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Import statements like `from x import y` are clear because the source of y is explicitly the x package or module.\n",
+    "* Wildcard imports like `from foo import *` make code more difficult to understand.\n",
+    "    * `from foo import *` hides the source of names from new readers of the code.\n",
+    "        * If a module has multiple `import *` statements, you'll need to check all of the referenced modules to figure out where a name was defined.\n",
+    "    * Names from `import *` statements will overwrite any conflicting names within the containing module.\n",
+    "        * This can lead to strange bugs caused by accidental interactions between your code and overlapping names from multiple `import *` statements.\n",
+    "    \n",
+    "        \n",
+    "    [Important!]\n",
+    "* Avoid `import *` in your code and explicitly import names with the `from x import y` style."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Things to Remember"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Packages in Python are modules that contain other modules.\n",
+    "    * Packages allow you to organize your code into separate, non-conflicting `namespaces` with unique absolute module names.\n",
+    "* Simple packages are defined by adding an `__init__.py` file to a directory that contains other source files.\n",
+    "    * These files become the child modules of the directory's package.\n",
+    "    * Package directories may also contain other packages.\n",
+    "* You can provide an explicit API for a module by listing its publicly visibe names in its `__all__` special attribute.\n",
+    "* You can hide a package's internal implementation:\n",
+    "     * By only importing public names in the package's `__init__.py` file.\n",
+    "     * By naming internal-only members with a leading underscore.\n",
+    "* When collaborating within a single team or on a single codebase, using `__all__` for explicit APIs is probably unnecessary and should be avoided."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Add notebook for item 50: 
- Use Packages to Organize Modules and Provide Stable APIs